### PR TITLE
Ignorar archivos de CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+#Don't track css
+/css
+
+.vscode
+
+.cpanel.yml


### PR DESCRIPTION
Los archivos de CSS no deben subirse en cada Pull ya que en cada lugar dónde esta el proyecto se reinterpretan por el preprosesador de SASS, a producción si subiremos los CSS porque es lo que interpretan los navegadores