### PR TITLE
Bug "Sin mesas"

### DIFF
--- a/js/table.js
+++ b/js/table.js
@@ -25,7 +25,9 @@ jQuery(function($) {
         .siblings(".error")
         .hide();
       $("#date-time").removeClass("input-text--error");
-      llenarMesas($("#clients").val(), $("#date-time").val());
+      if ($("#clients").val()){
+        llenarMesas($("#clients").val(), $("#date-time").val());
+      }
     }
   });
 


### PR DESCRIPTION
## ¿Qué hice?

- Mensaje "Sin mesas"
  Obtendrá las mesas hasta que seccionen una fecha y numero de personas  ya que quitaba el mensaje de "Selecciona"
 
## Ejemplo
![numeroPersonasMesas](https://user-images.githubusercontent.com/48694003/56977453-d22dc180-6b3a-11e9-9f40-cef2df690a83.png)
