### PR TITLE
Reemplazar caracter ' 

### DIFF
--- a/model/ReservationsBO.php
+++ b/model/ReservationsBO.php
@@ -93,7 +93,7 @@ class ReservationsBO
 
     $query = "INSERT INTO `reservaciones` ";
     $query .= "(`ID_ESPECTACULO`, `ID_MESA`, `ID_FECHA_HR`, `NOMBRE_COMPLETO`, `CORREO`, `CELULAR`, `DEPOSITO_REALIZADO`, `NO_PERSONAS`, `FOLIO`) VALUES ";
-    $query .= "(" . $reservation->id_show . ", " . $reservation->id_table . ", " . $reservation->id_date_hr . ", '" . $reservation->full_name . "', '" . $reservation->mail . "', " . $reservation->cell_phone . ", '0', " . $reservation->no_people . ", '" . $var_Folio . "')";
+    $query .= "(" . $reservation->id_show . ", " . $reservation->id_table . ", " . $reservation->id_date_hr . ", '" . str_replace("'", "\'",$reservation->full_name) . "', '" . $reservation->mail . "', " . $reservation->cell_phone . ", '0', " . $reservation->no_people . ", '" . $var_Folio . "')";
     $resultQuery = $databaseConected->consulta($query);
     $databaseConected->desconectar();
     if ($resultQuery) {


### PR DESCRIPTION
## ¿Qué hice?

- Agregue código str_replace(), para reemplazar carácter ', al registrar una reservación 

## Ejemplo
![replace](https://user-images.githubusercontent.com/48694003/57083471-36c55980-6cbe-11e9-9aa8-2e8e4233fac8.png)
